### PR TITLE
Fix parsing of free's output with recent procps

### DIFF
--- a/nagios/plugins/check_memory
+++ b/nagios/plugins/check_memory
@@ -104,12 +104,25 @@ open(RESULT, "$FREECMD -b |")
   or $np->nagios_exit('CRITICAL', "Could not run $FREECMD");
 
 warn("Output from $FREECMD:\n") if ($verbose > 1);
-my ($used, $free);
+my ($used, $free, $available_col);
 while (<RESULT>) {
   warn("  $_") if ($verbose > 1);
-  next unless (m#^\-/\+\ buffers/cache:\s*(\d+)\s+(\d+)#);
-  $used = $1;
-  $free = $2;
+  if (m/available$/) {
+    $available_col = 1;
+    next;
+  }
+  if (defined($available_col)) {
+    if (m#(\d+)(?:\s+\d+){3}\s+(\d+)$#) {
+      ($used, $free) = ($1, $2);
+      last
+    }
+  }
+  else {
+    if (m#^\-/\+\ buffers/cache:\s*(\d+)\s+(\d+)#) {
+      ($used, $free) = ($1, $2);
+      last
+    }
+  }
 }
 
 close(RESULT);


### PR DESCRIPTION
Hi, the `-/+ buffers` line has been removed in recent versions of free. The relevant commit is here: https://gitorious.org/procps/vnwildman-procps/commit/f47001c9e91a1e9b12db4497051a212cf49a87b1
This patch fixes the check to work with both old and recent versions of procps' free. 